### PR TITLE
extrapolate for points outside the convex hull by returning the value of the nearest neighbor sample point.

### DIFF
--- a/src/main/java/edu/mines/jtk/interp/SibsonInterpolator2.java
+++ b/src/main/java/edu/mines/jtk/interp/SibsonInterpolator2.java
@@ -334,7 +334,7 @@ public class SibsonInterpolator2 {
       return _fnull;
     double asum = computeAreas(x1,x2);
     if (asum<=0.0)
-      return _fnull;
+      return f(_mesh.findNodeNearest(x1,x2));
     if (usingGradients()) {
       return interpolate1(asum,x1,x2);
     } else {

--- a/src/main/java/edu/mines/jtk/interp/SibsonInterpolator3.java
+++ b/src/main/java/edu/mines/jtk/interp/SibsonInterpolator3.java
@@ -356,7 +356,7 @@ public class SibsonInterpolator3 {
       return _fnull;
     double vsum = computeVolumes(x1,x2,x3);
     if (vsum<=0.0)
-      return _fnull;
+      return f(_mesh.findNodeNearest(x1,x2,x3));
     if (usingGradients()) {
       return interpolate1(vsum,x1,x2,x3);
     } else {


### PR DESCRIPTION
Patch supplied by my colleague; Please could you check if it is worth pulling it in?

My colleagues discription: 

Before:
Sibson's interpolant is undefined at points on or outside the convex hull of sample points. In this sense, Sibson interpolation does not extrapolate; the interpolant is implicitly bounded by the convex hull, and null values are returned when attempting to interpolate outside those bounds.

After:
Sibson’s interpolant will extrapolate for points outside the convex hull by returning the value of the nearest neighbor sample point.